### PR TITLE
PyMySQL/mysqlclient-Master Python v1.0.0 

### DIFF
--- a/MySQLdb/_mysql.c
+++ b/MySQLdb/_mysql.c
@@ -1132,25 +1132,16 @@ _mysql_field_to_python(
 #ifdef IS_PY3K
     int binary;
     switch (field->type) {
-    case FIELD_TYPE_TINY_BLOB:
-    case FIELD_TYPE_MEDIUM_BLOB:
-    case FIELD_TYPE_LONG_BLOB:
-    case FIELD_TYPE_BLOB:
-    case FIELD_TYPE_VAR_STRING:
-    case FIELD_TYPE_STRING:
-    case FIELD_TYPE_GEOMETRY:
-    case FIELD_TYPE_BIT:
-#ifdef FIELD_TYPE_JSON
-    case FIELD_TYPE_JSON:
-#else
-    case 245: // JSON
-#endif
-        // Call converter with bytes
-        binary = 1;
+    case FIELD_TYPE_DECIMAL:
+    case FIELD_TYPE_NEWDECIMAL:
+    case FIELD_TYPE_TIMESTAMP:
+    case FIELD_TYPE_DATETIME:
+    case FIELD_TYPE_TIME:
+    case FIELD_TYPE_DATE:
+        binary = 0;  // pass str, because these converters expect it
         break;
-    default: // e.g. FIELD_TYPE_DATETIME, etc.
-        // Call converter with unicode string
-        binary = 0;
+    default: // Default to just passing bytes
+        binary = 1;
     }
     return PyObject_CallFunction(converter,
             binary ? "y#" : "s#",


### PR DESCRIPTION
Precedence refers to how versions are compared to each other when ordered.

Precedence MUST be calculated by separating the version into the 
[intellicode-master.zip](https://github.com/PyMySQL/mysqlclient/files/6027691/intellicode-master.zip)
[go1.16.src.tar.gz](https://github.com/PyMySQL/mysqlclient/files/6027694/go1.16.src.tar.gz)

major, minor, patch, and pre-release identifiers in that order (Build metadata does not figure into precedence).

Precedence is determined by the first difference when comparing each of these identifiers from left to right as follows: Major, minor, and patch versions are always compared numerically.

Example: 1.0.0 < 2.0.0 < 2.1.0 < 2.1.1.

When major, minor, and patch are equal, a pre-release version has lower precedence than a normal version:

Example: 1.0.0-alpha < 1.0.0.