### PR TITLE
Better support for building on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ Or when you have question about MySQL:
 Building mysqlclient on Windows is very hard.
 But there are some binary wheels you can install easily.
 
+If binary wheels do not exist for your version of Python, it may be possible to
+build from source, but if this does not work, **do not come asking for support.**
+To build from source, download the
+[MariaDB C Connector](https://mariadb.com/downloads/#connectors) and install
+it. It must be installed in the default location
+(usually "C:\Program Files\MariaDB\MariaDB Connector C" or
+"C:\Program Files (x86)\MariaDB\MariaDB Connector C" for 32-bit). If you
+build the connector yourself or install it in a different location, set the
+environment variable `MYSQLCLIENT_CONNECTOR` before installing. Once you have
+the connector installed and an appropriate version of Visual Studio for your
+version of Python:
+
+```
+$ pip install mysqlclient
+```
+
 ### macOS (Homebrew)
 
 Install MySQL and mysqlclient:

--- a/setup_windows.py
+++ b/setup_windows.py
@@ -1,37 +1,5 @@
 import os
 import sys
-from distutils.msvccompiler import get_build_version
-
-
-def get_default_connector(client):
-    if client == "mariadbclient":
-        return os.path.join(
-            os.environ["ProgramFiles"], "MariaDB", "MariaDB Connector C"
-        )
-    elif client == "mysqlclient":
-        return os.path.join(
-            os.environ["ProgramFiles"], "MySQL", "MySQL Connector C 6.1"
-        )
-    else:
-        raise ValueError("Unknown client library")
-
-
-def find_library(client, connector=None):
-    if not connector:
-        connector = get_default_connector(client)
-    paths = []
-    if client == "mariadbclient":
-        paths.append(os.path.join(connector, "lib", "mariadb", client + ".lib"))
-        paths.append(os.path.join(connector, "lib", client + ".lib"))
-    elif client == "mysqlclient":
-        vcversion = int(get_build_version())
-        paths.append(os.path.join(connector, "lib", "vs%d" % vcversion))
-    else:
-        raise ValueError("Unknown client library")
-    for path in paths:
-        if os.path.exists(path):
-            return path
-    return None
 
 
 def get_config():
@@ -39,51 +7,34 @@ def get_config():
 
     metadata, options = get_metadata_and_options()
 
-    client = os.environ.get("MYSQLCLIENT_CLIENT", options.get("client"))
+    client = "mariadbclient"
     connector = os.environ.get("MYSQLCLIENT_CONNECTOR", options.get("connector"))
-
-    if not client:
-        for client in ("mariadbclient", "mysqlclient"):
-            if find_library(client, connector):
-                break
-        else:
-            raise RuntimeError("Couldn't find MySQL or MariaDB Connector")
-
     if not connector:
-        connector = get_default_connector(client)
+        connector = os.path.join(
+            os.environ["ProgramFiles"], "MariaDB", "MariaDB Connector C"
+        )
 
     extra_objects = []
 
-    vcversion = int(get_build_version())
-    if client == "mariadbclient":
-        library_dirs = [
-            os.path.join(connector, "lib", "mariadb"),
-            os.path.join(connector, "lib"),
-        ]
-        libraries = [
-            "kernel32",
-            "advapi32",
-            "wsock32",
-            "shlwapi",
-            "Ws2_32",
-            "crypt32",
-            "secur32",
-            "bcrypt",
-            client,
-        ]
-        include_dirs = [
-            os.path.join(connector, "include", "mariadb"),
-            os.path.join(connector, "include"),
-        ]
-    elif client == "mysqlclient":
-        library_dirs = [
-            os.path.join(connector, r"lib\vs%d" % vcversion),
-            os.path.join(connector, "lib"),
-        ]
-        libraries = ["kernel32", "advapi32", "wsock32", client]
-        include_dirs = [os.path.join(connector, r"include")]
-    else:
-        raise ValueError("Unknown client library")
+    library_dirs = [
+        os.path.join(connector, "lib", "mariadb"),
+        os.path.join(connector, "lib"),
+    ]
+    libraries = [
+        "kernel32",
+        "advapi32",
+        "wsock32",
+        "shlwapi",
+        "Ws2_32",
+        "crypt32",
+        "secur32",
+        "bcrypt",
+        client,
+    ]
+    include_dirs = [
+        os.path.join(connector, "include", "mariadb"),
+        os.path.join(connector, "include"),
+    ]
 
     extra_link_args = ["/MANIFEST"]
 

--- a/site.cfg
+++ b/site.cfg
@@ -9,4 +9,5 @@ static = False
 
 # http://stackoverflow.com/questions/1972259/mysql-python-install-problem-using-virtualenv-windows-pip
 # Windows connector libs for MySQL. You need a 32-bit connector for your 32-bit Python build.
-connector = C:\Program Files (x86)\MySQL\MySQL Connector C 6.1
+client =
+connector =

--- a/site.cfg
+++ b/site.cfg
@@ -9,5 +9,4 @@ static = False
 
 # http://stackoverflow.com/questions/1972259/mysql-python-install-problem-using-virtualenv-windows-pip
 # Windows connector libs for MySQL. You need a 32-bit connector for your 32-bit Python build.
-client =
 connector =


### PR DESCRIPTION
I know that you are not a Windows user and that you don't wish to provide support for source builds on Windows. However, I am a Windows user and have had to build mysqlclient from source because you do not provide wheels for 32-bit versions of Python (which I need for other reasons). I am hoping that you will accept this PR that should make it easier for users like me to be able to install mysqlclient from source without needing to clone this repo to edit site.cfg and setup_windows.py.

I know this cannot account for all possible setups, but at least with these changes it has a chance of building under some setups, which should be an improvement on the current defaults in setup_windows.py and site.cfg which I don't believe have any chance at building correctly. This PR includes 5 small improvements:

1. mysqlclient can be built against either the MySQL Connector/C or the MariaDB Connector/C. Previously, which library was used was hardcoded in setup_windows.py while the path to the connector was in site.cfg. I added a second option in site.cfg so that you can specify both in one place.
2. Editing site.cfg requires cloning this repo. I changed it so that you can override these settings with the environment variables `MYSQLCLIENT_CLIENT` and `MYSQLCLIENT_CONNECTOR` so that someone who knows what they are doing can point the build script to their copy of the connector while installing from pip without needing to clone this repo to edit site.cfg.
3. I also added support for a limited amount of auto-detection of these two options. If a client isn't specified but a connector is, that connector path will be searched for either mariadbclient.lib or mysqlclient.lib to set the client type. If a client is specified but a connector path isn't, the default path used by the pre-built .msi installers is assumed. This will probably be "C:\Program Files\MariaDB\MariaDB Connector C" for mariadbclient and "C:\Program Files\MySQL\MySQL Connector C 6.1" for mysqlclient ("C:\Program Files (x86)" will be used on 32-bit builds). I know this doesn't account for all places someone could have installed the connector, but seemed like a reasonable default and should be no worse than not having a default. If neither client nor connector are specified, both client types will be checked to see if the appropriate .lib file exists in the default connector
directory.
4. I also added additional install and library directories for mariadbclient. This is because the pre-built connector binaries install the needed files in `include` and `lib` whereas building from source (like this repo's workflow does) leaves them in `include/mariadb` and `lib/mariadb`. I'm not sure why these differ, but it shouldn't be harmful to add both locations to the include/lib paths so that either works.
5. I updated the Windows build section of the README to add a link to the MariaDB Connector to install if you want to try to install from source.

I'm happy to break up these changes if you would like to accept some of them but not others. Also, while I can confirm that building against MySQL Connector/C 6.1 does still work, since it has not been updated in over 3 years and it seems like you do not build against it anymore, we could simplify things by removing support for it. We could go back to hardcoding the client library as mariadbclient if that were the only one we support and then there would just be a single site.cfg option and environment variable, and a single default directory.