### PR TITLE
update remnants of passwd and db also in docs

### DIFF
--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -125,19 +125,19 @@ We haven't even begun to touch upon all the parameters ``connect()``
 can take.  For this reason, I prefer to use keyword parameters::
 
     db=_mysql.connect(host="localhost",user="joebob",
-                      passwd="moonpie",db="thangs")
+                      password="moonpie",database="thangs")
 
 This does exactly what the last example did, but is arguably easier to
 read. But since the default host is "localhost", and if your login
 name really was "joebob", you could shorten it to this::
 
-    db=_mysql.connect(passwd="moonpie",db="thangs")
+    db=_mysql.connect(password="moonpie",database="thangs")
 
 UNIX sockets and named pipes don't work over a network, so if you
 specify a host other than localhost, TCP will be used, and you can
 specify an odd port if you need to (the default port is 3306)::
 
-    db=_mysql.connect(host="outhouse",port=3307,passwd="moonpie",db="thangs")
+    db=_mysql.connect(host="outhouse",port=3307,password="moonpie",database="thangs")
 
 If you really had to, you could connect to the local host with TCP by
 specifying the full host name, or 127.0.0.1.
@@ -145,7 +145,7 @@ specifying the full host name, or 127.0.0.1.
 Generally speaking, putting passwords in your code is not such a good
 idea::
 
-    db=_mysql.connect(host="outhouse",db="thangs",read_default_file="~/.my.cnf")
+    db=_mysql.connect(host="outhouse",database="thangs",read_default_file="~/.my.cnf")
 
 This does what the previous example does, but gets the username and
 password and other parameters from ~/.my.cnf (UNIX-like systems). Read
@@ -561,7 +561,7 @@ Some examples
 The ``connect()`` method works nearly the same as with `MySQLDB._mysql`_::
 
     import MySQLdb
-    db=MySQLdb.connect(passwd="moonpie",db="thangs")
+    db=MySQLdb.connect(password="moonpie",database="thangs")
 
 To perform a query, you first need a cursor, and then you can execute
 queries on it::


### PR DESCRIPTION
As a follow up to fa25358d0f171bd8a63729c5a8d76528f4ae74e9 also change the remnants of `passwd` and `db` in the user documentation.