### PR TITLE
Remove bytes encoder that was specifically for Django 1.11

### DIFF
--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -186,13 +186,6 @@ class Connection(_mysql.connection):
         self.cursorclass = cursorclass
         self.encoders = {k: v for k, v in conv.items() if type(k) is not int}
 
-        # XXX THIS IS GARBAGE: While this is just a garbage and undocumented,
-        # Django 1.11 depends on it.  And they don't fix it because
-        # they are in security-only fix mode.
-        # So keep this garbage for now.  This will be removed in 1.5.
-        # See PyMySQL/mysqlclient-python#306
-        self.encoders[bytes] = bytes
-
         self._server_version = tuple(
             [numeric_part(n) for n in self.get_server_info().split(".")[:2]]
         )


### PR DESCRIPTION
Fixes #489 

Seems this may have just been missed in https://github.com/PyMySQL/mysqlclient/pull/411