### PR TITLE
Fix encoding mismatch cp1252 -> latin1

### DIFF
--- a/MySQLdb/_mysql.c
+++ b/MySQLdb/_mysql.c
@@ -221,7 +221,7 @@ _get_encoding(MYSQL *mysql)
         return utf8;
     }
     else if (strncmp("latin1", cs.csname, 6) == 0) {
-        return "cp1252";
+        return "latin1";
     }
     else if (strncmp("koi8r", cs.csname, 5) == 0) {
         return "koi8_r";

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -24,7 +24,7 @@ from ._exceptions import (
 _charset_to_encoding = {
     "utf8mb4": "utf8",
     "utf8mb3": "utf8",
-    "latin1": "cp1252",
+    "latin1": "latin1",
     "koi8r": "koi8_r",
     "koi8u": "koi8_u",
 }


### PR DESCRIPTION
I know encoding can be a complex and sensitive topic, and is very common to mislabel cp1252 for latin1, so i will be straightforward with this issue: 

**Bytes in the range  \x80 - \x9f :**
 
- in cp1252 or windows-1252 are "somewhat undefined" 
- in latin1 or ISO/IEC 8859-1:1998 map to C1 control characters

Microsoft created cp1252 based on latin1, and then, later on used this **"empty" \x80 - \x9f  address range** to accommodate European characters.

**References:**
- C1 control characters: https://en.wikipedia.org/wiki/C0_and_C1_control_codes
- latin1 details: https://en.wikipedia.org/wiki/ISO/IEC_8859-1
- cp1252 details: https://en.wikipedia.org/wiki/Windows-1252#Character_set
- latin1 specification (Page 63): https://datatracker.ietf.org/doc/html/rfc1345
- cp1252 specification: https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WindowsBestFit/bestfit1252.txt

Some useful **discussions:**
- https://comp.lang.python.narkive.com/C9oHYxxu/latin1-and-cp1252-inconsistent
- https://stackoverflow.com/questions/58501530/python3-different-behaviour-between-latin-1-and-cp1252-when-decoding-unmapped-ch


In python3 you can verify the behavior by running this (i ran this in 3.8.10): 
```
for x in range(0,256):
   try:
      chr(x).encode('cp1252')
   except:
      print(f'cp1252 Failed to encode {x} - {hex(x)}')
      try:
         latin1_char = chr(x).encode('latin1')
         print(f'latin1 Encoded {x} - {hex(x)} to: {latin1_char}')
      except:
         print(f'latin1 Failed to encode {x} - {hex(x)}')
      print()
```

Encoding that range with cp1252, will throw exceptions, whereas in latin1 they will map to those C1 control characters. 

This PR will fix issues like this: #498 
I traced the addition of cp1252 from here: #390 