### PR TITLE
Update python_requires to match supported python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ metadata["ext_modules"] = [
 ]
 metadata["long_description"] = readme
 metadata["long_description_content_type"] = "text/markdown"
-metadata["python_requires"] = ">=3.5"
+metadata["python_requires"] = ">=3.7"
 setuptools.setup(**metadata)


### PR DESCRIPTION
In https://github.com/PyMySQL/mysqlclient/commit/684dcbf0657f18c1ba12fe21732323c890ff20ab and https://github.com/PyMySQL/mysqlclient/commit/dac24e7b05b83eb1511e25e3cd8f8c20b7fbe112 it looks like Python 3.6 support has been dropped. This change updates `python_requires` to match so tools like `pip` know not to install the next version in a Python 3.6 environment.