### PR TITLE
docs: fix simple typo, portible -> portable

### DIFF
--- a/tests/dbapi20.py
+++ b/tests/dbapi20.py
@@ -56,7 +56,7 @@ import time
 # - self.populate is now self._populate(), so if a driver stub
 #   overrides self.ddl1 this change propagates
 # - VARCHAR columns now have a width, which will hopefully make the
-#   DDL even more portible (this will be reversed if it causes more problems)
+#   DDL even more portable (this will be reversed if it causes more problems)
 # - cursor.rowcount being checked after various execute and fetchXXX methods
 # - Check for fetchall and fetchmany returning empty lists after results
 #   are exhausted (already checking for empty lists if select retrieved


### PR DESCRIPTION
There is a small typo in tests/dbapi20.py.

Should read `portable` rather than `portible`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md