### PR TITLE
ignore the UnicodeDecodeError when some bytes cannot be decoded with …

### DIFF
--- a/MySQLdb/_mysql.c
+++ b/MySQLdb/_mysql.c
@@ -1155,10 +1155,10 @@ _mysql_field_to_python(
     if (converter == (PyObject*)&PyUnicode_Type) {
         if (encoding == utf8) {
             //fprintf(stderr, "decoding with utf8!\n");
-            return PyUnicode_DecodeUTF8(rowitem, length, NULL);
+            return PyUnicode_DecodeUTF8(rowitem, length, "replace");
         } else {
             //fprintf(stderr, "decoding with %s\n", encoding);
-            return PyUnicode_Decode(rowitem, length, encoding, NULL);
+            return PyUnicode_Decode(rowitem, length, encoding, "replace");
         }
     }
     if (converter == (PyObject*)&PyBytes_Type || converter == Py_None) {


### PR DESCRIPTION
sometime the function cursor.fetchall() raise exceptions like follower:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc4 in position 0: invalid continuation byte
```
this exception is very annoying if you don't fix the records which include the Garbled character.
