### PR TITLE
Add collation option

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: Start MySQL
         run: |

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -100,7 +100,7 @@ class Connection(_mysql.connection):
             If omitted, empty string, or None, the default character set
             from the server will be used.
 
-        :param str collate:
+        :param str collation:
             If ``charset`` and ``collation`` are both supplied, the
             character set and collation for the current conneciton
             will be set.
@@ -179,7 +179,7 @@ class Connection(_mysql.connection):
 
         cursorclass = kwargs2.pop("cursorclass", self.default_cursor)
         charset = kwargs2.get("charset", "")
-        collate = kwargs2.pop("collate", "")
+        collation = kwargs2.pop("collation", "")
         use_unicode = kwargs2.pop("use_unicode", True)
         sql_mode = kwargs2.pop("sql_mode", "")
         self._binary_prefix = kwargs2.pop("binary_prefix", False)
@@ -204,8 +204,8 @@ class Connection(_mysql.connection):
 
         self.encoding = "ascii"  # overridden in set_character_set()
 
-        if charset and collate:
-            self.set_character_set_collation(charset, collate)
+        if charset and collation:
+            self.set_character_set_collation(charset, collation)
         else:
             if not charset:
                 charset = self.character_set_name()
@@ -313,11 +313,11 @@ class Connection(_mysql.connection):
         super().set_character_set(charset)
         self.encoding = _charset_to_encoding.get(charset, charset)
 
-    def set_character_set_collation(self, charset, collate):
+    def set_character_set_collation(self, charset, collation):
         """Set the connection character set and collation. Use this as
         an alternative to ``set_character_set``.
         """
-        self.query("SET NAMES %s COLLATE %s" % (charset, collate))
+        self.query("SET NAMES %s COLLATE %s" % (charset, collation))
         self.store_result()
         self.encoding = _charset_to_encoding.get(charset, charset)
 

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -97,12 +97,9 @@ class Connection(_mysql.connection):
             If supplied, the connection character set will be changed
             to this character set.
 
-            If omitted, empty string, or None, the default character set
-            from the server will be used.
-
         :param str collation:
             If ``charset`` and ``collation`` are both supplied, the
-            character set and collation for the current conneciton
+            character set and collation for the current connection
             will be set.
 
             If omitted, empty string, or None, the default collation
@@ -204,12 +201,9 @@ class Connection(_mysql.connection):
 
         self.encoding = "ascii"  # overridden in set_character_set()
 
-        if charset and collation:
-            self.set_character_set_collation(charset, collation)
-        else:
-            if not charset:
-                charset = self.character_set_name()
-            self.set_character_set(charset)
+        if not charset:
+            charset = self.character_set_name()
+        self.set_character_set(charset, collation)
 
         if sql_mode:
             self.set_sql_mode(sql_mode)
@@ -308,18 +302,13 @@ class Connection(_mysql.connection):
         """
         self.query(b"BEGIN")
 
-    def set_character_set(self, charset):
+    def set_character_set(self, charset, collation = None):
         """Set the connection character set to charset."""
         super().set_character_set(charset)
         self.encoding = _charset_to_encoding.get(charset, charset)
-
-    def set_character_set_collation(self, charset, collation):
-        """Set the connection character set and collation. Use this as
-        an alternative to ``set_character_set``.
-        """
-        self.query("SET NAMES %s COLLATE %s" % (charset, collation))
-        self.store_result()
-        self.encoding = _charset_to_encoding.get(charset, charset)
+        if collation:
+            self.query("SET NAMES %s COLLATE %s" % (charset, collation))
+            self.store_result()
 
     def set_sql_mode(self, sql_mode):
         """Set the connection sql_mode. See MySQL documentation for

--- a/MySQLdb/connections.py
+++ b/MySQLdb/connections.py
@@ -302,7 +302,7 @@ class Connection(_mysql.connection):
         """
         self.query(b"BEGIN")
 
-    def set_character_set(self, charset, collation = None):
+    def set_character_set(self, charset, collation=None):
         """Set the connection character set to charset."""
         super().set_character_set(charset)
         self.encoding = _charset_to_encoding.get(charset, charset)

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -336,15 +336,28 @@ connect(parameters...)
             *This must be a keyword parameter.*
 
          charset
-            If present, the connection character set will be changed
-            to this character set, if they are not equal. Support for
-            changing the character set requires MySQL-4.1 and later
-            server; if the server is too old, UnsupportedError will be
-            raised. This option implies use_unicode=True, but you can
-            override this with use_unicode=False, though you probably
-            shouldn't.
+            If supplied, the connection character set will be changed
+            to this character set.
 
-            If not present, the default character set is used.
+            If omitted, empty string, or None, the default character
+            set from the server will be used.
+
+            *This must be a keyword parameter.*
+
+         collate
+
+            If ``charset`` and ``collation`` are both supplied, the
+            character set and collation for the current conneciton
+            will be set.
+
+            If omitted, empty string, or None, the default collation
+            for the ``charset`` is implied by the database server.
+
+            To learn more about the quiddities of character sets and
+            collations, consult the `MySQL docs
+            <https://dev.mysql.com/doc/refman/8.0/en/charset.html>`_
+            and `MariaDB docs
+            <https://mariadb.com/kb/en/character-sets/>`_
 
             *This must be a keyword parameter.*
 

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -336,18 +336,21 @@ connect(parameters...)
             *This must be a keyword parameter.*
 
          charset
-            If supplied, the connection character set will be changed
-            to this character set.
+            If present, the connection character set will be changed
+            to this character set, if they are not equal. Support for
+            changing the character set requires MySQL-4.1 and later
+            server; if the server is too old, UnsupportedError will be
+            raised. This option implies use_unicode=True, but you can
+            override this with use_unicode=False, though you probably
+            shouldn't.
 
-            If omitted, empty string, or None, the default character
-            set from the server will be used.
+            If not present, the default character set is used.
 
             *This must be a keyword parameter.*
 
          collation
-
             If ``charset`` and ``collation`` are both supplied, the
-            character set and collation for the current conneciton
+            character set and collation for the current connection
             will be set.
 
             If omitted, empty string, or None, the default collation

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -344,9 +344,9 @@ connect(parameters...)
 
             *This must be a keyword parameter.*
 
-         collate
+         collation
 
-            If ``charset`` and ``collate`` are both supplied, the
+            If ``charset`` and ``collation`` are both supplied, the
             character set and collation for the current conneciton
             will be set.
 

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -346,7 +346,7 @@ connect(parameters...)
 
          collate
 
-            If ``charset`` and ``collation`` are both supplied, the
+            If ``charset`` and ``collate`` are both supplied, the
             character set and collation for the current conneciton
             will be set.
 

--- a/tests/test_MySQLdb_nonstandard.py
+++ b/tests/test_MySQLdb_nonstandard.py
@@ -124,13 +124,13 @@ class TestCollation(unittest.TestCase):
         # collation.
         self.conn = connection_factory(
             charset="utf8mb4",
-            collate="utf8mb4_esperanto_ci",
+            collation="utf8mb4_esperanto_ci",
         )
 
     def tearDown(self):
         self.conn.close()
 
-    def test_charset_collate(self):
+    def test_charset_collation(self):
         c = self.conn.cursor()
         c.execute(
             """
@@ -141,6 +141,6 @@ class TestCollation(unittest.TestCase):
         )
         row = c.fetchall()
         charset = row[0][1]
-        collate = row[1][1]
+        collation = row[1][1]
         self.assertEqual(charset, "utf8mb4")
-        self.assertEqual(collate, "utf8mb4_esperanto_ci")
+        self.assertEqual(collation, "utf8mb4_esperanto_ci")

--- a/tests/test_MySQLdb_nonstandard.py
+++ b/tests/test_MySQLdb_nonstandard.py
@@ -114,3 +114,33 @@ class CoreAPI(unittest.TestCase):
         with connection_factory() as conn:
             self.assertFalse(conn.closed)
         self.assertTrue(conn.closed)
+
+
+class TestCollation(unittest.TestCase):
+    """Test charset and collation connection options."""
+
+    def setUp(self):
+        # Initialize a connection with a non-default character set and
+        # collation.
+        self.conn = connection_factory(
+            charset="utf8mb4",
+            collate="utf8mb4_esperanto_ci",
+        )
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_charset_collate(self):
+        c = self.conn.cursor()
+        c.execute(
+            """
+            SHOW VARIABLES WHERE
+            Variable_Name="character_set_connection" OR
+            Variable_Name="collation_connection";
+            """
+        )
+        row = c.fetchall()
+        charset = row[0][1]
+        collate = row[1][1]
+        self.assertEqual(charset, "utf8mb4")
+        self.assertEqual(collate, "utf8mb4_esperanto_ci")


### PR DESCRIPTION
Fixes #563 

This change does not affect existing behavior if the `collate` option is not specified.

To test this out locally, e.g. in a Django project:
* Make sure you have MySQL or MariaDB C connector, and a C compiler installed.
* `pip install git+https://github.com/vsalvino/mysqlclient.git`
* Set your database connection as so:

```python
DATABASES = {
    "default": {
        "ENGINE": "django.db.backends.mysql",
        "HOST": "",
        "NAME": "",
        "USER": "",
        "PASSWORD": "",
        "OPTIONS": {
            "charset": "utf8mb4",
            "collation": "utf8mb4_unicode_ci",
        },
    }
}
```