### PR TITLE
Improved exception handling when importing the module

### DIFF
--- a/MySQLdb/__init__.py
+++ b/MySQLdb/__init__.py
@@ -13,12 +13,11 @@ For information on how MySQLdb handles type conversion, see the
 MySQLdb.converters module.
 """
 
-try:
-    from MySQLdb.release import version_info
-    from . import _mysql
+# Check if the version of _mysql matches the version of MySQLdb.
+from MySQLdb.release import version_info
+from . import _mysql
 
-    assert version_info == _mysql.version_info
-except Exception:
+if version_info != _mysql.version_info:
     raise ImportError(
         "this is MySQLdb version {}, but _mysql is version {!r}\n_mysql: {!r}".format(
             version_info, _mysql.version_info, _mysql.__file__


### PR DESCRIPTION
The current expection handling is too vague, and in certain circumstances, the error message may confuse the user.

For example, if an error occurs while importing the "_mysql" module, the original error message is as follows:

```
  File "MySQLdb/__init__.py", line 18, in <module>
    from . import _mysql
ImportError: /lib64/libstdc++.so.6: cannot allocate memory in static TLS block
```

But on the user side, he can only see the exception message like this: 

```
/MySQLdb/__init__.py", line 24, in <module>
    version_info, _mysql.version_info, _mysql.__file__
NameError: name '_mysql' is not defined
```

This PR fixes this issue by making the exception handling statements more precise.