### PR TITLE
fix: fix sslmode typo

### DIFF
--- a/src/MySQLdb/_mysql.c
+++ b/src/MySQLdb/_mysql.c
@@ -531,11 +531,12 @@ _mysql_ConnectionObject_Initialize(
         // See https://github.com/PyMySQL/mysqlclient/issues/474
         // TODO: Does MariaDB supports PREFERRED and VERIFY_CA?
         // We support only two levels for now.
+        my_bool enforce_tls = 1;
         if (ssl_mode_num >= SSLMODE_REQUIRED) {
-            mysql_optionsv(&(self->connection), MYSQL_OPT_SSL_ENFORCE, 1);
+            mysql_optionsv(&(self->connection), MYSQL_OPT_SSL_ENFORCE, (void *)&enforce_tls);
         }
         if (ssl_mode_num >= SSLMODE_VERIFY_CA) {
-            mysql_optionsv(&(self->connection), MYSQL_OPT_SSL_VERIFY_SERVER_CERT, 1);
+            mysql_optionsv(&(self->connection), MYSQL_OPT_SSL_VERIFY_SERVER_CERT, (void *)&enforce_tls);
         }
 #endif
     }

--- a/src/MySQLdb/_mysql.c
+++ b/src/MySQLdb/_mysql.c
@@ -531,10 +531,10 @@ _mysql_ConnectionObject_Initialize(
         // See https://github.com/PyMySQL/mysqlclient/issues/474
         // TODO: Does MariaDB supports PREFERRED and VERIFY_CA?
         // We support only two levels for now.
-        if (sslmode_num >= SSLMODE_REQUIRED) {
+        if (ssl_mode_num >= SSLMODE_REQUIRED) {
             mysql_optionsv(&(self->connection), MYSQL_OPT_SSL_ENFORCE, (void *)&enforce_tls);
         }
-        if (sslmode_num >= SSLMODE_VERIFY_CA) {
+        if (ssl_mode_num >= SSLMODE_VERIFY_CA) {
             mysql_optionsv(&(self->connection), MYSQL_OPT_SSL_VERIFY_SERVER_CERT, (void *)&enforce_tls);
         }
 #endif

--- a/src/MySQLdb/_mysql.c
+++ b/src/MySQLdb/_mysql.c
@@ -532,10 +532,10 @@ _mysql_ConnectionObject_Initialize(
         // TODO: Does MariaDB supports PREFERRED and VERIFY_CA?
         // We support only two levels for now.
         if (ssl_mode_num >= SSLMODE_REQUIRED) {
-            mysql_optionsv(&(self->connection), MYSQL_OPT_SSL_ENFORCE, (void *)&enforce_tls);
+            mysql_optionsv(&(self->connection), MYSQL_OPT_SSL_ENFORCE, 1);
         }
         if (ssl_mode_num >= SSLMODE_VERIFY_CA) {
-            mysql_optionsv(&(self->connection), MYSQL_OPT_SSL_VERIFY_SERVER_CERT, (void *)&enforce_tls);
+            mysql_optionsv(&(self->connection), MYSQL_OPT_SSL_VERIFY_SERVER_CERT, 1);
         }
 #endif
     }


### PR DESCRIPTION
We are trying to use SSL with MariaDB and ran into the issue with `ssl_mode` (fixed by the recently merged #475). We tried installing the latest commit on `main` and it produces the following error when building:

```shell
running build_ext
      building 'MySQLdb._mysql' extension
      creating build/temp.linux-aarch64-cpython-310
      creating build/temp.linux-aarch64-cpython-310/src
      creating build/temp.linux-aarch64-cpython-310/src/MySQLdb
      gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC "-Dversion_info=(2, 2, 0, 'dev', 0)" -D__version__=2.2.0.dev0 -I/usr/local/include/python3.10 -c src/MySQLdb/_mysql.c -o build/temp.linux-aarch64-cpython-310/src/MySQLdb/_mysql.o -I/usr/include/mariadb/ -std=c99
      In file included from /usr/local/include/python3.10/Python.h:8,
                       from src/MySQLdb/_mysql.c:46:
      /usr/local/include/python3.10/pyconfig.h:1643: warning: "_POSIX_C_SOURCE" redefined
       1643 | #define _POSIX_C_SOURCE 200809L
            |
      In file included from /usr/include/aarch64-linux-gnu/sys/types.h:25,
                       from /usr/include/mariadb/mysql.h:38,
                       from src/MySQLdb/_mysql.c:29:
      /usr/include/features.h:310: note: this is the location of the previous definition
        310 | # define _POSIX_C_SOURCE 199506L
            |
      src/MySQLdb/_mysql.c: In function ‘_mysql_ConnectionObject_Initialize’:
      src/MySQLdb/_mysql.c:534:13: error: ‘sslmode_num’ undeclared (first use in this function); did you mean ‘ssl_mode_num’?
        534 |         if (sslmode_num >= SSLMODE_REQUIRED) {
            |             ^~~~~~~~~~~
            |             ssl_mode_num
      src/MySQLdb/_mysql.c:534:13: note: each undeclared identifier is reported only once for each function it appears in
      src/MySQLdb/_mysql.c:535:81: error: ‘enforce_tls’ undeclared (first use in this function)
        535 |             mysql_optionsv(&(self->connection), MYSQL_OPT_SSL_ENFORCE, (void *)&enforce_tls);
            |                                                                                 ^~~~~~~~~~~
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]
```

This PR fixes the sslmode typo and replaces `enforce_tls` with `1`.