### PR TITLE
Do not use MYSQL_OPT_RECONNECT as possible.

### DIFF
--- a/src/MySQLdb/connections.py
+++ b/src/MySQLdb/connections.py
@@ -192,7 +192,9 @@ class Connection(_mysql.connection):
 
         super().__init__(*args, **kwargs2)
         self.cursorclass = cursorclass
-        self.encoders = {k: v for k, v in conv.items() if type(k) is not int}
+        self.encoders = {
+            k: v for k, v in conv.items() if type(k) is not int  # noqa: E721
+        }
 
         self._server_version = tuple(
             [numeric_part(n) for n in self.get_server_info().split(".")[:2]]


### PR DESCRIPTION
MySQL 8.0.33+ shows deprecation warning to stderr.
So we avoid using it as possible.

In the future, we will deprecate `reconnect` option of the `Connection.ping()`.