### PR TITLE
Support building against Percona Server builds of MySQL client library `libperconaserverclient`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("src/MySQLdb/release.py", encoding="utf-8") as f:
 def find_package_name():
     """Get available pkg-config package name"""
     # Ubuntu uses mariadb.pc, but CentOS uses libmariadb.pc
-    packages = ["mysqlclient", "mariadb", "libmariadb"]
+    packages = ["mysqlclient", "mariadb", "libmariadb", "perconaserverclient"]
     for pkg in packages:
         try:
             cmd = f"pkg-config --exists {pkg}"


### PR DESCRIPTION
After #584, pkg-config is required. 

I use Percona Server for MySQL, and use both the server as well as their client library. Percona Server for MySQL began shipping a .pc file in https://github.com/percona/percona-server/pull/5215 Percona Server for MySQL 8.0.37, but the library name they ship is `perconaserverclient`:

```
$ pkg-config --exists perconaserverclient
$ echo $?
0
$ pkg-config --cflags perconaserverclient
-I/usr/include/mysql
$ pkg-config --libs perconaserverclient
-lperconaserverclient
```

This PR adds support for that name to pkg-config invocations.