### PR TITLE
add MariaDB to README and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@ This project adds Python 3 support and fixed many bugs.
 
 **Do Not use Github Issue Tracker to ask help.  OSS Maintainer is not free tech support**
 
-When your question looks relating to Python rather than MySQL:
+When your question looks relating to Python rather than MySQL/MariaDB:
 
 * Python mailing list [python-list](https://mail.python.org/mailman/listinfo/python-list)
 * Slack [pythondev.slack.com](https://pyslackers.com/web/slack)
 
-Or when you have question about MySQL:
+Or when you have question about MySQL/MariaDB:
 
 * [MySQL Community on Slack](https://lefred.be/mysql-community-on-slack/)
+* [MariaDB's Zulip instance](https://mariadb.zulipchat.com/)
 
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ When your question looks relating to Python rather than MySQL/MariaDB:
 
 Or when you have question about MySQL/MariaDB:
 
-* [MySQL Community on Slack](https://lefred.be/mysql-community-on-slack/)
-* [MariaDB's Zulip instance](https://mariadb.zulipchat.com/)
+* [MySQL Support](https://dev.mysql.com/support/)
+* [Getting Help With MariaDB](https://mariadb.com/kb/en/getting-help-with-mariadb/)
 
 
 ## Install

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -8,8 +8,8 @@ MySQLdb User's Guide
 Introduction
 ------------
 
-MySQLdb is an interface to the popular MySQL
-database server that provides the Python database API.
+MySQLdb is an interface to the popular MySQL or MariaDB
+database servers that provides the Python database API.
 
 Installation
 ------------


### PR DESCRIPTION
Suggest to add MariaDB to README and documentation intro as mentioned in https://github.com/PyMySQL/mysqlclient/issues/719 - hope this is ok? 