### PR TITLE
MariaDB include paths for Win

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ def get_config_win32(options):
     ]
     include_dirs = [
         os.path.join(connector, "include", "mariadb"),
+        os.path.join(connector, "include", "mysql"),
         os.path.join(connector, "include"),
     ]
 


### PR DESCRIPTION
*MariaDB 11.4.4* (from *.zip* file) header files are located under `${MYSQLCLIENT_CONNECTOR}/include/mysql`.<br>
Don't know how it was in previous versions, but without the above path in include list the *C* source file fails to compile.