### PR TITLE
add database name as the Connection attribute

### DIFF
--- a/src/MySQLdb/connections.py
+++ b/src/MySQLdb/connections.py
@@ -204,6 +204,8 @@ class Connection(_mysql.connection):
             if type(k) is not int  # noqa: E721
         }
 
+        self.database = kwargs2.get("database", "")
+
         self._server_version = tuple(
             [numeric_part(n) for n in self.get_server_info().split(".")[:2]]
         )


### PR DESCRIPTION
This change will add `self.database` as the Connection attribute displaying the database name from connection parameters.

I've described the reason for this change in https://github.com/PyMySQL/mysqlclient/discussions/751 . Moreover, I believe that this attribute can be useful for other use-case where the info about the database name can be useful.