### PR TITLE
support local_infile_dir option

### DIFF
--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -396,6 +396,17 @@ connect(parameters...)
         server_public_key_path
             specifies path to a RSA public key used by caching sha2 password authentication.
             See https://dev.mysql.com/doc/refman/9.0/en/caching-sha2-pluggable-authentication.html
+        
+        local_infile
+            sets ``MYSQL_OPT_LOCAL_INFILE`` in ``mysql_options()`` enabling LOAD LOCAL INFILE from any path; zero disables;
+
+            *This must be a keyword parameter.*
+        
+        local_infile_dir
+            sets ``MYSQL_OPT_LOAD_DATA_LOCAL_DIR`` in ``mysql_options()`` enabling LOAD LOCAL INFILE from any path; 
+            if ``local_infile`` is set to ``True`` then this is ignored;
+
+            *This must be a keyword parameter.*
 
 .. _mysql_ssl_set: http://dev.mysql.com/doc/refman/en/mysql-ssl-set.html
 

--- a/src/MySQLdb/connections.py
+++ b/src/MySQLdb/connections.py
@@ -142,7 +142,13 @@ class Connection(_mysql.connection):
             See https://dev.mysql.com/doc/refman/9.0/en/caching-sha2-pluggable-authentication.html
 
         :param bool local_infile:
-            enables LOAD LOCAL INFILE; zero disables
+            sets ``MYSQL_OPT_LOCAL_INFILE`` in ``mysql_options()`` enabling LOAD LOCAL INFILE from any path; zero disables;
+            
+        :param str local_infile_dir:
+            sets ``MYSQL_OPT_LOAD_DATA_LOCAL_DIR`` in ``mysql_options()`` enabling LOAD LOCAL INFILE from any path; 
+            if ``local_infile`` is set to ``True`` then this is ignored;
+            
+            supported for mysql version >= 8.0.21
 
         :param bool autocommit:
             If False (default), autocommit is disabled.


### PR DESCRIPTION
Adds support for `MYSQL_OPT_LOAD_DATA_LOCAL_DIR` in `mysql_options()` as the kwarg `local_infile_dir`. A bit safer alternative than `local_infile` for MySQL versions >= 8.0.21.

(P.S. I'm a bit out of my depth with this PR but tried my best following the example of a previous PR with a similar addition, if there is anything that needs changing I'm happy to do it.)

Thank you for reviewing!