### PR TITLE
Python 3.14 build

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.14'
+          python-version: '3.13'
           cache: 'pip'
           cache-dependency-path: 'ci/django-requirements.txt'
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'ci/django-requirements.txt'
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,7 +68,7 @@ jobs:
     env:
       PIP_NO_PYTHON_VERSION_WARNING: 1
       PIP_DISABLE_PIP_VERSION_CHECK: 1
-      DJANGO_VERSION: '4.2.16'
+      DJANGO_VERSION: '5.2.7'
     steps:
       - name: Start MySQL
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: ["main"]
+    branches: ['main']
   pull_request:
 
 jobs:
@@ -13,9 +13,9 @@ jobs:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         include:
-          - python-version: "3.12"
+          - python-version: '3.12'
             mariadb: 1
     steps:
       - if: ${{ matrix.mariadb }}
@@ -41,8 +41,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: "requirements.txt"
+          cache: 'pip'
+          cache-dependency-path: 'requirements.txt'
           allow-prereleases: true
 
       - name: Install mysqlclient
@@ -52,7 +52,7 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install -r requirements.txt
-      
+
       - name: Run tests
         env:
           TESTDB: actions.cnf
@@ -62,13 +62,13 @@ jobs:
       - uses: codecov/codecov-action@v5
 
   django-test:
-    name: "Run Django LTS test suite"
+    name: 'Run Django LTS test suite'
     needs: test
     runs-on: ubuntu-latest
     env:
       PIP_NO_PYTHON_VERSION_WARNING: 1
       PIP_DISABLE_PIP_VERSION_CHECK: 1
-      DJANGO_VERSION: "4.2.16"
+      DJANGO_VERSION: '4.2.16'
     steps:
       - name: Start MySQL
         run: |
@@ -83,9 +83,9 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: "ci/django-requirements.txt"
+          python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: 'ci/django-requirements.txt'
 
       - name: Install mysqlclient
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,7 +68,7 @@ jobs:
     env:
       PIP_NO_PYTHON_VERSION_WARNING: 1
       PIP_DISABLE_PIP_VERSION_CHECK: 1
-      DJANGO_VERSION: '5.2.7'
+      DJANGO_VERSION: '4.2.16'
     steps:
       - name: Start MySQL
         run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -74,15 +74,18 @@ jobs:
           cat site.cfg
 
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14.0'
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel
+        run: python -m pip install --upgrade cibuildwheel
       - name: Build wheels
         working-directory: mysqlclient
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.9'
           CIBW_ARCHS: 'AMD64'
+          CIBW_BUILD: 'cp3*-win_amd64'
           CIBW_TEST_COMMAND: 'python -c "import MySQLdb; print(MySQLdb.version_info)" '
-        run: 'python -m cibuildwheel --output-dir dist' # We removed '--prerelease-pythons', Python 3.14 is still flagged as prerelease but has been released
+        run: 'python -m cibuildwheel --output-dir dist'
 
       - name: Build sdist
         working-directory: mysqlclient

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -82,7 +82,7 @@ jobs:
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.9'
           CIBW_ARCHS: 'AMD64'
           CIBW_TEST_COMMAND: 'python -c "import MySQLdb; print(MySQLdb.version_info)" '
-        run: 'python -m cibuildwheel --prerelease-pythons --output-dir dist'
+        run: 'python -m cibuildwheel --output-dir dist' # We removed '--prerelease-pythons', Python 3.14 is still flagged as prerelease but has been released
 
       - name: Build sdist
         working-directory: mysqlclient

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -2,7 +2,7 @@ name: Build windows wheels
 
 on:
   push:
-    branches: ["main", "ci"]
+    branches: ['main', 'ci']
   pull_request:
   workflow_dispatch:
 
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: windows-latest
     env:
-      CONNECTOR_VERSION: "3.4.1"
+      CONNECTOR_VERSION: '3.4.7'
     steps:
       - name: Cache Connector
         id: cache-connector
@@ -79,10 +79,10 @@ jobs:
       - name: Build wheels
         working-directory: mysqlclient
         env:
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
-          CIBW_ARCHS: "AMD64"
+          CIBW_PROJECT_REQUIRES_PYTHON: '>=3.9'
+          CIBW_ARCHS: 'AMD64'
           CIBW_TEST_COMMAND: 'python -c "import MySQLdb; print(MySQLdb.version_info)" '
-        run: "python -m cibuildwheel --prerelease-pythons --output-dir dist"
+        run: 'python -m cibuildwheel --prerelease-pythons --output-dir dist'
 
       - name: Build sdist
         working-directory: mysqlclient

--- a/ci/test_mysql.py
+++ b/ci/test_mysql.py
@@ -19,7 +19,7 @@ DATABASES = {
         "HOST": "127.0.0.1",
         "USER": "scott",
         "PASSWORD": "tiger",
-        "TEST": {"CHARSET": "utf8mb3", "COLLATION": "utf8mb3_general_ci"},
+        "TEST": {"CHARSET": "utf8mb4", "COLLATION": "utf8mb4_general_ci"},
     },
     "other": {
         "ENGINE": "django.db.backends.mysql",
@@ -27,7 +27,7 @@ DATABASES = {
         "HOST": "127.0.0.1",
         "USER": "scott",
         "PASSWORD": "tiger",
-        "TEST": {"CHARSET": "utf8mb3", "COLLATION": "utf8mb3_general_ci"},
+        "TEST": {"CHARSET": "utf8mb4", "COLLATION": "utf8mb4_general_ci"},
     },
 }
 


### PR DESCRIPTION
- Bumped CONNECTOR_VERSION to the latest version 3.4.1 -> 3.4.7
- Bumped Django version to the latest version 4.2.16 -> 5.2.7
- Added Python 3.14 in matrix strategy

I did not intend to change `"` to `'` in certain cases but my IDE insisted.

---
## Why this PR?

I've decided to upgrade my Django stack from Python `3.13.3` to `3.14.0` and this package is one of those packages which have not been updated yet to support Python 3.14.0. 

```
  × Building wheel for mysqlclient (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [81 lines of output]
      C:\Users\ME\AppData\Local\Temp\pip-build-env-iqxgzq2g\overlay\Lib\site-packages\setuptools\config\_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
      !!

              ********************************************************************************
              Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).        

              By 2026-Feb-18, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************

      !!
        corresp(dist, value, root_dir)
      C:\Users\ME\AppData\Local\Temp\pip-build-env-iqxgzq2g\overlay\Lib\site-packages\setuptools\config\_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!

              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:

              License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************

      !!
        dist._finalize_license_expression()
      C:\Users\ME\AppData\Local\Temp\pip-build-env-iqxgzq2g\overlay\Lib\site-packages\setuptools\dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!

              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:

              License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************

      !!
        self._finalize_license_expression()
      # Options for building extension module:
        library_dirs: ['C:/mariadb-connector\\lib\\mariadb', 'C:/mariadb-connector\\lib']
        libraries: ['kernel32', 'advapi32', 'wsock32', 'shlwapi', 'Ws2_32', 'crypt32', 'secur32', 'bcrypt', 'mariadbclient']
        extra_link_args: ['/MANIFEST']
        include_dirs: ['C:/mariadb-connector\\include\\mariadb', 'C:/mariadb-connector\\include\\mysql', 'C:/mariadb-connector\\include']
        extra_objects: []
        define_macros: [('version_info', (2, 2, 7, 'final', 0)), ('__version__', '2.2.7')]
      running bdist_wheel
      running build
      running build_py
      creating build\lib.win-amd64-cpython-314\MySQLdb
      copying src\MySQLdb\connections.py -> build\lib.win-amd64-cpython-314\MySQLdb
      copying src\MySQLdb\converters.py -> build\lib.win-amd64-cpython-314\MySQLdb
      copying src\MySQLdb\cursors.py -> build\lib.win-amd64-cpython-314\MySQLdb
      copying src\MySQLdb\release.py -> build\lib.win-amd64-cpython-314\MySQLdb
      copying src\MySQLdb\times.py -> build\lib.win-amd64-cpython-314\MySQLdb
      copying src\MySQLdb\_exceptions.py -> build\lib.win-amd64-cpython-314\MySQLdb
      copying src\MySQLdb\__init__.py -> build\lib.win-amd64-cpython-314\MySQLdb
      creating build\lib.win-amd64-cpython-314\MySQLdb\constants
      copying src\MySQLdb\constants\CLIENT.py -> build\lib.win-amd64-cpython-314\MySQLdb\constants
      copying src\MySQLdb\constants\CR.py -> build\lib.win-amd64-cpython-314\MySQLdb\constants
      copying src\MySQLdb\constants\ER.py -> build\lib.win-amd64-cpython-314\MySQLdb\constants
      copying src\MySQLdb\constants\FIELD_TYPE.py -> build\lib.win-amd64-cpython-314\MySQLdb\constants
      copying src\MySQLdb\constants\FLAG.py -> build\lib.win-amd64-cpython-314\MySQLdb\constants
      copying src\MySQLdb\constants\__init__.py -> build\lib.win-amd64-cpython-314\MySQLdb\constants
      running egg_info
      writing src\mysqlclient.egg-info\PKG-INFO
      writing dependency_links to src\mysqlclient.egg-info\dependency_links.txt
      writing top-level names to src\mysqlclient.egg-info\top_level.txt
      reading manifest file 'src\mysqlclient.egg-info\SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      adding license file 'LICENSE'
      writing manifest file 'src\mysqlclient.egg-info\SOURCES.txt'
      copying src\MySQLdb\_mysql.c -> build\lib.win-amd64-cpython-314\MySQLdb
      running build_ext
      building 'MySQLdb._mysql' extension
      creating build\temp.win-amd64-cpython-314\Release\src\MySQLdb
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.41.34120\bin\HostX86\x64\cl.exe" /c /nologo /O2 /W3 /GL /DNDEBUG /MD "-Dversion_info=(2, 2, 7, 'final', 0)" -D__version__=2.2.7 -IC:/mariadb-connector\include\mariadb -IC:/mariadb-connector\include\mysql -IC:/mariadb-connector\include -ID:\work\Project\APP-Backend\venv\include -IC:\Users\ME\AppData\Local\Programs\Python\Python314\include -IC:\Users\ME\AppData\Local\Programs\Python\Python314\Include "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.41.34120\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\VS\include" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\um" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\shared" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\winrt" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.22621.0\\cppwinrt" "-IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\include\um" /Tcsrc/MySQLdb/_mysql.c /Fobuild\temp.win-amd64-cpython-314\Release\src\MySQLdb\_mysql.obj
      _mysql.c
      src/MySQLdb/_mysql.c(29): fatal error C1083: Cannot open include file: 'mysql.h': No such file or directory
      error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Tools\\MSVC\\14.41.34120\\bin\\HostX86\\x64\\cl.exe' failed with exit code 2
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for mysqlclient
Failed to build mysqlclient
```

## Solution?
I've compiled mysqlclient.whl for my windows system running Python `3.14.0`, Django `5.2.7` and MariaDB C Connector `3.4.7`
[dist.zip](https://github.com/user-attachments/files/23194510/dist.zip) and it works.

I've bumped versions in the CI/CD Pipeline in the hopes the pip issue will resolve once the correct build for the mysqlclient wheel package is available on pip. However, it seems to me that the Pipeline is not responsible for publishing to PyPi.
