### PR TITLE
update pyproject.toml to support Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.8"
 authors = [
     {name = "Inada Naoki", email = "songofacandy@gmail.com"}
 ]
-license = {text = "GNU General Public License v2 or later (GPLv2+)"}
+license = "GNU General Public License v2 or later (GPLv2+)"
 keywords = ["MySQL"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,11 @@ requires-python = ">=3.8"
 authors = [
     {name = "Inada Naoki", email = "songofacandy@gmail.com"}
 ]
-license = "GNU-General-Public-License-v2-or-later-(GPLv2+)"
+license = "GPL-2.0-or-later"
 keywords = ["MySQL"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Other Environment",
-    "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows :: Windows NT/2000",
     "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.8"
 authors = [
     {name = "Inada Naoki", email = "songofacandy@gmail.com"}
 ]
-license = "GNU General Public License v2 or later (GPLv2+)"
+license = "GNU-General-Public-License-v2-or-later-(GPLv2+)"
 keywords = ["MySQL"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Database",
     "Topic :: Database :: Database Engines/Servers",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "mysqlclient"
 description = "Python interface to MySQL"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     {name = "Inada Naoki", email = "songofacandy@gmail.com"}
 ]
@@ -20,8 +20,6 @@ classifiers = [
     "Programming Language :: C",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ def get_config_win32(options):
     connector = os.environ.get("MYSQLCLIENT_CONNECTOR", options.get("connector"))
     if not connector:
         connector = os.path.join(
-            os.environ["ProgramFiles"], "MariaDB", "MariaDB Connector C",
+            os.environ["ProgramFiles"], "MariaDB", "MariaDB Connector C"
         )
 
     extra_objects = []

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,8 @@ def get_config_win32(options):
     connector = os.environ.get("MYSQLCLIENT_CONNECTOR", options.get("connector"))
     if not connector:
         connector = os.path.join(
-            os.environ["ProgramFiles"], "MariaDB", "MariaDB Connector C"
+            os.environ["ProgramFiles"], "MariaDB", "MariaDB Connector C",
+            os.environ["ProgramFiles"], "MariaDB", "MariaDB Connector C 64-bit",
         )
 
     extra_objects = []

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,6 @@ def get_config_win32(options):
     if not connector:
         connector = os.path.join(
             os.environ["ProgramFiles"], "MariaDB", "MariaDB Connector C",
-            os.environ["ProgramFiles"], "MariaDB", "MariaDB Connector C 64-bit",
         )
 
     extra_objects = []


### PR DESCRIPTION
Suggested changes to fix deprecation and changes to format of project.license in python 3.14: C:\Users\XXX\AppData\Local\Temp\pip-build-env-cc_fwjqb\overlay\Lib\site-packages\setuptools\config\_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
      !!

              ********************************************************************************
              Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

              By 2026-Feb-18, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************

      !!
        corresp(dist, value, root_dir)
      C:\Users\XXX\AppData\Local\Temp\pip-build-env-cc_fwjqb\overlay\Lib\site-packages\setuptools\config\_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!

              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:

              License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************

      !!
        dist._finalize_license_expression()
      C:\Users\XXX\AppData\Local\Temp\pip-build-env-cc_fwjqb\overlay\Lib\site-packages\setuptools\dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!

              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:

              License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************
And also to fix build errors when using the 64 bit MariaDB Connector C, but not sure if this is the correct way.